### PR TITLE
Set minimum version for module

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.71.0"
+      version = "> 3.70.0"
     }
   }
 }


### PR DESCRIPTION
Generally modules shouldn't have a specific version required as that's just annoying for consumers, set a minimum version instead